### PR TITLE
Do not pass os.Stdin to launched command

### DIFF
--- a/common.go
+++ b/common.go
@@ -475,7 +475,7 @@ func CopyFile(src, dest string) error {
 	return nil
 }
 
-//Appends contents of source file to destination file.
+// Appends contents of source file to destination file.
 // If destination file is not present, Copy file action is performed
 func AppendToFile(srcFile, destFile string) error {
 	if FileExists(destFile) {
@@ -542,7 +542,6 @@ func prepareCommand(isSystemCommand bool, command []string, workingDir string, o
 	cmd.Dir = workingDir
 	cmd.Stdout = outputStreamWriter
 	cmd.Stderr = errorStreamWriter
-	cmd.Stdin = os.Stdin
 	return cmd
 }
 


### PR DESCRIPTION
This is related to https://github.com/getgauge/gauge/issues/2419
- removes problematic line
- references issue in the code
- updates the dependencies in order to get go build and go test working

Signed-off by: Lukas Bockstaller <lukas.bockstaller@posteo.de>